### PR TITLE
Fix waitForStaticTimeout not being honored properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -205,7 +205,7 @@ if (static) {
       const start = Date.now()
       let exists  = false
       while(!exists) {
-        if (Date.now() - start > waitForLockfilesTimeout) {
+        if (Date.now() - start > waitForStaticTimeout) {
           throw new Error(`timed out waiting for file to exist`)
         }
         exists = await existsAsync(file)


### PR DESCRIPTION
I noticed that the `waitForStaticTimeout` parameter wasn't working properly, and missing files were raising the error immediately, instead of waiting for the timeout, I tracked it down to this typo.